### PR TITLE
Add the ability to configure the timestamp format to 12H (#1)

### DIFF
--- a/config.template
+++ b/config.template
@@ -34,6 +34,12 @@
 # Show linescores. Requires scores=true above.
 #linescore=false
 
+# Change the format of timestrings printed
+# One of "12H" "24H"
+# 	Note: "24H" is the default
+#   Uncomment the following line to enable timestamps to print in 12 hour format with AM/PM
+#timeformat=12H
+
 # Show full article content in --info output
 # info_display_articles=true
 

--- a/mlbv/mlbam/common/util.py
+++ b/mlbv/mlbam/common/util.py
@@ -102,6 +102,8 @@ def convert_time_to_local(d):
     from_zone = tz.tzutc()
     to_zone = tz.tzlocal()
     utc = d.replace(tzinfo=from_zone)
+    if config.CONFIG.parser['timeformat'] == '12H':
+        return utc.astimezone(to_zone).strftime('%I:%M %p')
     return utc.astimezone(to_zone).strftime('%H:%M')
 
 

--- a/mlbv/mlbam/mlbconfig.py
+++ b/mlbv/mlbam/mlbconfig.py
@@ -38,5 +38,6 @@ DEFAULTS = {  # is applied to initial config before reading from file - these ar
         'verify_ssl': 'true',
         'save_json_file_by_timestamp': 'false',
         'unicode': 'true',
+        'timeformat': '24H'
     }
 }


### PR DESCRIPTION
Allow for the printing of timestamps in 12 hour format, configurable via the config file